### PR TITLE
feat: insert translation keys present in other languages

### DIFF
--- a/resources/js/components/LocalizeList.vue
+++ b/resources/js/components/LocalizeList.vue
@@ -59,7 +59,23 @@ export default {
 
     computed: {
         translations() {
-            return this.trackedSites[this.site].translations
+            const createEmptyTranslationKeys = (obj1, obj2) => {
+                for (let key in obj2) {
+                    if (obj2.hasOwnProperty(key) && !obj1.hasOwnProperty(key)) {
+                        if (obj2[key] instanceof Object) {
+                            obj1[key] = {}
+                            obj1[key] = createEmptyTranslationKeys(obj1[key], obj2[key])
+                        } else {
+                            obj1[key] = ''
+                        }
+                    }
+                }
+                return obj1;
+            }
+            const otherSites = Object.keys(this.trackedSites).filter(x => x !== this.site)
+            let result = this.trackedSites[this.site].translations
+            otherSites.forEach((s) => {result = createEmptyTranslationKeys(result, this.trackedSites[s].translations)})
+            return result
         },
         strings() {
             return Object.entries(this.translations).reduce((acc, [key, value]) => {


### PR DESCRIPTION
In our usual development process, we add keys to `de.json` and ask the customer to fill in the other languages.

When switching the Statamic CP to another language, currently the localize plugin only shows the i18n keys present in that language. So when switching to a language where keys have not been set up yet (let's say `fr`), only those keys present in the `fr.json` will be shown.

This PR makes it so that keys from all other languages are merged into the requested language.